### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - nightly
+
+matrix:
+    allow_failures:
+        - php: nightly
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,17 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^5.7 || ^6.5",
         "friendsofphp/php-cs-fixer": "^2.3"
     },
     "autoload": {
         "psr-4": {
             "PHLAK\\SemVer\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PHLAK\\Semver\\Tests\\": "tests/"
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,4 +5,9 @@
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+     <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use PHLAK\SemVer;
+namespace PHLAK\SemVer\Tests;
 
-class VersionTest extends PHPUnit_Framework_TestCase
+use PHLAK\SemVer;
+use PHPUnit\Framework\TestCase;
+
+class VersionTest extends TestCase
 {
     public function setUp()
     {
@@ -14,11 +17,12 @@ class VersionTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(SemVer\Version::class, $this->version);
     }
 
+    /**
+     * @expectedException PHLAK\SemVer\Exceptions\InvalidVersionException
+     */
     public function test_it_throws_a_runtime_exception_for_an_invalid_version()
     {
-        $this->setExpectedException(SemVer\Exceptions\InvalidVersionException::class);
-
-        $version = new SemVer\Version('not.a.version');
+        new SemVer\Version('not.a.version');
     }
 
     public function test_it_can_set_and_retrieve_a_version()
@@ -125,6 +129,16 @@ class VersionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->version->gt(new SemVer\Version('v1.3.36')));
         $this->assertFalse($this->version->gt(new SemVer\Version('v1.3.38')));
         $this->assertFalse($this->version->gt(new SemVer\Version('v1.3.37')));
+        $this->assertTrue($this->version->gt(new SemVer\Version('v1.3.35')));
+    }
+
+    public function test_it_can_be_greater_than_another_major_semver_object()
+    {
+        $major = $this->version->setMajor(1.3);
+        $semver = new SemVer\Version('v1.3.38');
+        $semverMajor = $semver->setMajor(1.2);
+
+        $this->assertTrue($major->gt($semverMajor));
     }
 
     public function test_it_can_be_less_than_another_semver_object()


### PR DESCRIPTION
# Changed log
- Use class-based PHPUnit namespace to be compatible with latest PHPHUnit version.
- Add ```php-7.x``` and ```php-nightly``` tests and allow nightly to be failed in Travis CI build.
- Add more tests.
- After the PHPUnit version ```6.0```, the ````setExpectedException``` is deprecated.
To be compatible with the ```5.7```, we should use the expected exception annotation.