### PR TITLE
run phpunit through composer test

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,13 @@ Troubleshooting
 
 Please report bugs to the [GitHub Issue Tracker](https://github.com/PHLAK/SemVer/issues).
 
+Testing
+---------------
+```bash
+composer test
+```
+
 Copyright
 ---------
 
 This project is liscensed under the [MIT License](https://github.com/PHLAK/SemVer/blob/master/LICENSE).
-

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,8 @@
         "psr-4": {
             "PHLAK\\Semver\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }


### PR DESCRIPTION
When testing, I think it would be nice to have a way to run `phpunit` easily (i.e., without having to type `vendor/bin/phpunit` every time).

This PR adds `composer test` command that does just that.