### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 matrix:

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class VersionTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->version = new SemVer\Version('v1.3.37');
     }


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test on Travis CI build.
- According to the [Fixtures reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), `PHPUnit\Framework\TestCase::setUp` should be `protected`, not `public`.