### PR TITLE
Fix version comparaison according to semver.org rules

### DIFF
--- a/src/Traits/Comparable.php
+++ b/src/Traits/Comparable.php
@@ -14,12 +14,18 @@ trait Comparable
      * @return bool True if this Version object is greater than the comparing
      *              object, otherwise false
      */
-    public function gt(Version $version) : bool
+    public function gt(Version $version): bool
     {
-        $thisVersion = [$this->major, $this->minor, $this->patch, $this->preRelease];
-        $thatVersion = [$version->major, $version->minor, $version->patch, $version->preRelease];
+        // compare without prerelease
+        $thisVersion = [$this->major, $this->minor, $this->patch];
+        $thatVersion = [$version->major, $version->minor, $version->patch];
+        $result = $thisVersion <=> $thatVersion;
+        // if both version are equal we should compare pre release only if both property are sets
+        if (0 === $result) {
+            $result = $this->comparePrerelease($this->preRelease, $version->preRelease);
+        }
 
-        return ($thisVersion <=> $thatVersion) == 1;
+        return 1 === $result;
     }
 
     /**
@@ -30,12 +36,17 @@ trait Comparable
      * @return bool True if this Version object is less than the comparing
      *              object, otherwise false
      */
-    public function lt(Version $version) : bool
+    public function lt(Version $version): bool
     {
-        $thisVersion = [$this->major, $this->minor, $this->patch, $this->preRelease];
-        $thatVersion = [$version->major, $version->minor, $version->patch, $version->preRelease];
+        $thisVersion = [$this->major, $this->minor, $this->patch];
+        $thatVersion = [$version->major, $version->minor, $version->patch];
+        $result = $thisVersion <=> $thatVersion;
+        // if both version are equal we should compare pre release only if both property are sets
+        if (0 === $result) {
+            $result = $this->comparePrerelease($this->preRelease, $version->preRelease);
+        }
 
-        return ($thisVersion <=> $thatVersion) == -1;
+        return $result === -1;
     }
 
     /**
@@ -46,12 +57,12 @@ trait Comparable
      * @return bool True if this Version object is equal to the comparing
      *              object, otherwise false
      */
-    public function eq(Version $version) : bool
+    public function eq(Version $version): bool
     {
         $thisVersion = [$this->major, $this->minor, $this->patch, $this->preRelease];
         $thatVersion = [$version->major, $version->minor, $version->patch, $version->preRelease];
 
-        return ($thisVersion <=> $thatVersion) == 0;
+        return ($thisVersion <=> $thatVersion) === 0;
     }
 
     /**
@@ -62,12 +73,12 @@ trait Comparable
      * @return bool True if this Version object is not equal to the comparing
      *              object, otherwise false
      */
-    public function neq(Version $version) : bool
+    public function neq(Version $version): bool
     {
         $thisVersion = [$this->major, $this->minor, $this->patch, $this->preRelease];
         $thatVersion = [$version->major, $version->minor, $version->patch, $version->preRelease];
 
-        return ($thisVersion <=> $thatVersion) != 0;
+        return ($thisVersion <=> $thatVersion) !== 0;
     }
 
     /**
@@ -78,12 +89,17 @@ trait Comparable
      * @return bool True if this Version object is greater than or equal to the
      *              comparing object, otherwise false
      */
-    public function gte(Version $version) : bool
+    public function gte(Version $version): bool
     {
-        $thisVersion = [$this->major, $this->minor, $this->patch, $this->preRelease];
-        $thatVersion = [$version->major, $version->minor, $version->patch, $version->preRelease];
+        $thisVersion = [$this->major, $this->minor, $this->patch];
+        $thatVersion = [$version->major, $version->minor, $version->patch];
+        $result = $thisVersion <=> $thatVersion;
+        // if both version are equal we should compare pre release only if both property are sets
+        if (0 === $result) {
+            $result = $this->comparePrerelease($this->preRelease, $version->preRelease);
+        }
 
-        return ($thisVersion <=> $thatVersion) >= 0;
+        return $result >= 0;
     }
 
     /**
@@ -94,11 +110,52 @@ trait Comparable
      * @return bool True if this Version object is less than or equal to the
      *              comparing object, otherwise false
      */
-    public function lte(Version $version) : bool
+    public function lte(Version $version): bool
     {
-        $thisVersion = [$this->major, $this->minor, $this->patch, $this->preRelease];
-        $thatVersion = [$version->major, $version->minor, $version->patch, $version->preRelease];
+        $thisVersion = [$this->major, $this->minor, $this->patch];
+        $thatVersion = [$version->major, $version->minor, $version->patch];
+        $result = $thisVersion <=> $thatVersion;
+        // if both version are equal we should compare pre release only if both property are sets
+        if (0 === $result) {
+            $result = $this->comparePrerelease($this->preRelease, $version->preRelease);
+        }
 
-        return ($thisVersion <=> $thatVersion) <= 0;
+        return $result <= 0;
+    }
+
+    /**
+     * return 1 if $prerelease is greater than $prerelease, 0 if equal else -1.
+     *
+     * @param $prerelease1
+     * @param $prerelease2
+     *
+     * @return int
+     */
+    private function comparePrerelease($prerelease1, $prerelease2): int
+    {
+        // empty pre-release is greater than filled one
+        if ($prerelease1 === null && $prerelease2 !== null) {
+            return 1;
+        }
+        if ($prerelease1 !== null && $prerelease2 === null) {
+            return -1;
+        }
+        // pre-release can be composed of multiple pre-release identifier like alpha.beta.1 or .beta.11
+        // beta.2 is smaller than beta.11 we should split each identifier and compare them
+        $prereleaseList1 = explode('.', $prerelease1);
+        $prereleaseList2 = explode('.', $prerelease2);
+        // both list must have the same size
+        $prereleaseList1 = array_pad($prereleaseList1, count($prereleaseList2), null);
+        $prereleaseList2 = array_pad($prereleaseList2, count($prereleaseList1), null);
+        $result = 0;
+        foreach ($prereleaseList1 as $idx => $pre1) {
+            $pre2 = $prereleaseList2[$idx];
+            $result = $pre1 <=> $pre2;
+            if (0 !== $result) {
+                return $result;
+            }
+        }
+
+        return $result;
     }
 }

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -255,4 +255,47 @@ class VersionTest extends TestCase
         $this->assertTrue($oldBuild->gte($newBuild));
         $this->assertTrue($oldBuild->lte($newBuild));
     }
+
+    /**
+     * @param $release
+     * @param $prerelease
+     *
+     * @dataProvider versions_provider
+     */
+    public function test_it_compares_pre_release_tags_vs_release($release, $prerelease)
+    {
+        $release = new SemVer\Version($release);
+        $prerelease = new SemVer\Version($prerelease);
+
+        $this->assertFalse($release->eq($prerelease));
+        $this->assertFalse($release->lt($prerelease));
+        $this->assertFalse($release->lte($prerelease));
+        $this->assertTrue($release->gt($prerelease));
+        $this->assertTrue($release->gte($prerelease));
+
+        $this->assertFalse($prerelease->gt($release));
+        $this->assertFalse($prerelease->eq($release));
+        $this->assertFalse($prerelease->gte($release));
+        $this->assertTrue($prerelease->lt($release));
+        $this->assertTrue($prerelease->lte($release));
+    }
+
+    public function versions_provider()
+    {
+        $versions = [];
+        $versions[] = ['v1.3.37', 'v1.3.37-alpha'];
+        $versions[] = ['v1.3.37', 'v1.3.37-alpha.5+007'];
+        $versions[] = ['v1.3.0', 'v1.3.0-beta'];
+        $versions[] = ['v1.0.0', 'v1.0.0-rc1'];
+        //test case from http::/semver.org
+        $versions[] = ['1.0.0', '1.0.0-rc.1'];
+        $versions[] = ['1.0.0-rc.1', '1.0.0-beta.11'];
+        $versions[] = ['1.0.0-beta.11', '1.0.0-beta.2'];
+        $versions[] = ['1.0.0-beta.2', '1.0.0-beta'];
+        $versions[] = ['1.0.0-beta', '1.0.0-alpha.beta'];
+        $versions[] = ['1.0.0-alpha.beta', '1.0.0-alpha.1'];
+        $versions[] = ['1.0.0-alpha.1', '1.0.0-alpha'];
+
+        return $versions;
+    }
 }


### PR DESCRIPTION
Hi,
this PR will fix #14 bug by adding special method to compare pre-release parts when version core parts are equals.

Have a nice day.