### PR TITLE
increment prerelease method

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ $version = new SemVer\Version('v1.2.3');
 $version->incrementMajor(); // v1.2.3 -> v2.0.0
 $version->incrementMinor(); // v1.2.3 -> v1.3.0
 $version->incrementPatch(); // v1.2.3 -> v1.2.4
+$version->incrementPreRelease(); // v1.2.3-alpha.5 -> v1.2.3-alpha.6
 ```
 
 #### Set (override) the version or individual values

--- a/src/Traits/Incrementable.php
+++ b/src/Traits/Incrementable.php
@@ -49,7 +49,7 @@ trait Incrementable
     {
         if (is_null($this->preRelease)) {
             $this->incrementPatch();
-            $this->setPreRelease('0');
+            $this->setPreRelease('1');
 
             return $this;
         }
@@ -67,7 +67,7 @@ trait Incrementable
             $this->setPreRelease($number);
         } else {
             $preid = implode('.', $preRelease);
-            $this->setPreRelease($preid . '.0');
+            $this->setPreRelease($preid . '.1');
         }
 
         return $this;

--- a/src/Traits/Incrementable.php
+++ b/src/Traits/Incrementable.php
@@ -39,4 +39,37 @@ trait Incrementable
 
         return $this;
     }
+
+    /**
+     * Increment the pre-release version value by one.
+     *
+     * @return self This Version object
+     */
+    public function incrementPreRelease(): self
+    {
+        if (is_null($this->preRelease)) {
+            $this->incrementPatch();
+            $this->setPreRelease('0');
+
+            return $this;
+        }
+
+        $preRelease = explode('.', $this->preRelease);
+        $lastElement = trim(end($preRelease));
+
+        if (count($preRelease) > 1 && is_numeric($lastElement)) {
+            $number = intval($lastElement) + 1;
+            array_pop($preRelease);
+            $preid = implode('.', $preRelease);
+            $this->setPreRelease($preid . '.' . $number);
+        } elseif (count($preRelease) === 1 && is_numeric($lastElement)) {
+            $number = intval($lastElement) + 1;
+            $this->setPreRelease($number);
+        } else {
+            $preid = implode('.', $preRelease);
+            $this->setPreRelease($preid . '.0');
+        }
+
+        return $this;
+    }
 }

--- a/src/Version.php
+++ b/src/Version.php
@@ -66,7 +66,7 @@ class Version
     {
         $version = implode('.', [$this->major, $this->minor, $this->patch]);
 
-        if (! empty($this->preRelease)) {
+        if (! is_null($this->preRelease) && strlen($this->preRelease) > 0) {
             $version .= '-' . $this->preRelease;
         }
 

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -120,6 +120,59 @@ class VersionTest extends TestCase
         $this->assertEquals('1.3.38', (string) $version);
     }
 
+    public function test_it_can_increment_prerelease(): void
+    {
+        $version = new SemVer\Version('v1.3.37');
+        $version->setPreRelease('alpha.5');
+        $version->incrementPreRelease();
+
+        $this->assertEquals('1.3.37-alpha.6', (string) $version);
+    }
+
+    public function test_it_can_increment_prerelease_without_number(): void
+    {
+        $version = new SemVer\Version('v1.3.37');
+        $version->setPreRelease('alpha');
+        $version->incrementPreRelease();
+
+        $this->assertEquals('1.3.37-alpha.0', (string) $version);
+    }
+
+    public function test_it_can_increment_prerelease_without_prefix_for_prerelease(): void
+    {
+        $version = new SemVer\Version('v1.3.37');
+        $version->setPreRelease('5');
+        $version->incrementPreRelease();
+
+        $this->assertEquals('1.3.37-6', (string) $version);
+    }
+
+    public function test_it_can_increment_prerelease_containing_multiple_dots(): void
+    {
+        $version = new SemVer\Version('v1.3.37');
+        $version->setPreRelease('alpha.a.b.5');
+        $version->incrementPreRelease();
+
+        $this->assertEquals('1.3.37-alpha.a.b.6', (string) $version);
+    }
+
+    public function test_it_can_increment_prerelease_containing_multiple_dots_and_without_number(): void
+    {
+        $version = new SemVer\Version('v1.3.37');
+        $version->setPreRelease('alpha.a.b');
+        $version->incrementPreRelease();
+
+        $this->assertEquals('1.3.37-alpha.a.b.0', (string) $version);
+    }
+
+    public function test_it_can_increment_prerelease_and_patch_when_prerelease_is_null(): void
+    {
+        $version = new SemVer\Version('v1.3.37');
+        $version->incrementPreRelease();
+
+        $this->assertEquals('1.3.38-0', (string) $version);
+    }
+
     public function test_it_can_set_patch(): void
     {
         $version = new SemVer\Version('v1.3.37');

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -135,7 +135,7 @@ class VersionTest extends TestCase
         $version->setPreRelease('alpha');
         $version->incrementPreRelease();
 
-        $this->assertEquals('1.3.37-alpha.0', (string) $version);
+        $this->assertEquals('1.3.37-alpha.1', (string) $version);
     }
 
     public function test_it_can_increment_prerelease_without_prefix_for_prerelease(): void
@@ -162,7 +162,7 @@ class VersionTest extends TestCase
         $version->setPreRelease('alpha.a.b');
         $version->incrementPreRelease();
 
-        $this->assertEquals('1.3.37-alpha.a.b.0', (string) $version);
+        $this->assertEquals('1.3.37-alpha.a.b.1', (string) $version);
     }
 
     public function test_it_can_increment_prerelease_and_patch_when_prerelease_is_null(): void
@@ -170,7 +170,7 @@ class VersionTest extends TestCase
         $version = new SemVer\Version('v1.3.37');
         $version->incrementPreRelease();
 
-        $this->assertEquals('1.3.38-0', (string) $version);
+        $this->assertEquals('1.3.38-1', (string) $version);
     }
 
     public function test_it_can_set_patch(): void


### PR DESCRIPTION
This PR adds a method to increment the version of the prerelease
```php
$version->incrementPreRelease(); // v1.2.3-alpha.5 -> v1.2.3-alpha.6
```